### PR TITLE
[macOS] Update disk space Pester test: current target - 30 GB

### DIFF
--- a/images/macos/scripts/tests/System.Tests.ps1
+++ b/images/macos/scripts/tests/System.Tests.ps1
@@ -3,12 +3,13 @@ Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1"
 $os = Get-OSVersion
 
 Describe "Disk free space" {
-    It "Image has more than 14GB free space" {
-        # we should have at least 14 GB of free space on macOS images
+    It "Image has more than 30GB free space" {
+        # we should have at least 30 GB of free space on macOS images
         # 10GB here: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops#capabilities-and-limitations
         # 14GB here: https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+        # 30GB due to: https://github.com/actions/runner-images/issues/10511
         $freeSpace = (Get-PSDrive "/").Free
-        $freeSpace | Should -BeGreaterOrEqual 14GB
+        $freeSpace | Should -BeGreaterOrEqual 30GB
     }
 }
 


### PR DESCRIPTION
# Description

Minimum required 14 GB might be not enough for many projects unfortunately

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
